### PR TITLE
Use garbage collector for token strings and cleanup

### DIFF
--- a/main_program/execution.c
+++ b/main_program/execution.c
@@ -116,6 +116,7 @@ void execution(t_list *cmds, char **env)
                 info->exit_status = 1;
         }
         i++;
+    }
     while (i-- > 0)
     {
         waitpid(pids[i], &status, 0);

--- a/main_program/ft_alloc.c
+++ b/main_program/ft_alloc.c
@@ -97,8 +97,8 @@ void	free_tokens(t_tokens *tokens)
 	while (tokens)
 	{
 		tmp = tokens->next;
-		free(tokens->string);
-		free(tokens);
+                ft_free(tokens->string);
+                ft_free(tokens);
 		tokens = tmp;
 	}
 }

--- a/main_program/ft_utils.c
+++ b/main_program/ft_utils.c
@@ -45,9 +45,7 @@ char	*ft_substr(char *s, int len)
 	i = 0;
 	if (len <= 0)
 		return (NULL);
-	sub = malloc(sizeof(char) * (len + 1));
-	if (!sub)
-		return (NULL);
+        sub = ft_malloc(sizeof(char) * (len + 1));
 	while (s[i] && i < len)
 	{
 		sub[i] = s[i];

--- a/main_program/get_tokens.c
+++ b/main_program/get_tokens.c
@@ -53,9 +53,7 @@ static t_tokens	*stack_tokens(t_tokens *tokens, char *s)
 	t_tokens	*new;
 	t_tokens	*last;
 
-	new = malloc(sizeof(t_tokens));
-	if (!new)
-		return (free_tokens(tokens), exit(1), NULL);
+        new = ft_malloc(sizeof(t_tokens));
 	new->string = s;
 	new->flag = 0;
 	new->next = NULL;

--- a/main_program/list.c
+++ b/main_program/list.c
@@ -30,11 +30,11 @@ t_list	*new_node(t_list **list)
 	t_list	*node;
 	t_list	*tmp;
 
-	node = malloc(sizeof(t_list));
-	node->cmds = NULL;
-	node->rediraction = NULL;
-	node->next = NULL;
-	node->prev = NULL;
+        node = ft_malloc(sizeof(t_list));
+        node->cmds = NULL;
+        node->rediraction = NULL;
+        node->next = NULL;
+        node->prev = NULL;
 	if (!*list)
 		*list = node;
 	else
@@ -53,10 +53,10 @@ void	add_rediraction(t_rediraction **red, t_tokens *tokens)
 	t_rediraction	*node;
 	t_rediraction	*tmp;
 
-	node = malloc(sizeof(t_rediraction));
+        node = ft_malloc(sizeof(t_rediraction));
 	node->prev = NULL;
 	node->next = NULL;
-	node->token = tokens->next->string;
+        node->token = ft_strdup(tokens->next->string);
 	node->type = tokens->flag;
 	node->ambiguous = 0;
 	if ((tokens->next->next && tokens->next->flag == tokens->next->next->flag)
@@ -77,19 +77,21 @@ void	add_rediraction(t_rediraction **red, t_tokens *tokens)
 t_list	*tokens_to_list(t_tokens *tokens)
 {
 	int		i;
-	t_list	*list;
-	t_list	*tmp;
+	t_list  *list;
+        t_list  *tmp;
+        t_tokens        *head;
 
 	list = NULL;
+        head = tokens;
 	while (tokens)
 	{
 		tmp = new_node(&list);
 		i = 0;
-                tmp->cmds = malloc(sizeof(char *) * (count_words(tokens) + 1));
+                tmp->cmds = ft_malloc(sizeof(char *) * (count_words(tokens) + 1));
 		while (tokens && tokens->flag != TOKEN_PIPE)
 		{
 			if (tokens->flag == TOKEN_WORD)
-				tmp->cmds[i++] = tokens->string;
+				tmp->cmds[i++] = ft_strdup(tokens->string);
 			else if (ft_strchr(RED, tokens->flag))
 				add_rediraction(&tmp->rediraction, tokens);
 			tokens = tokens->next;
@@ -98,5 +100,34 @@ t_list	*tokens_to_list(t_tokens *tokens)
 		if (tokens && tokens->flag == TOKEN_PIPE)
 			tokens = tokens->next;
 	}
-	return (list);
+        free_tokens(head);
+        return (list);
+}
+
+void    free_command_list(t_list *list)
+{
+        t_list          *next;
+        t_rediraction   *r_next;
+        int             i;
+
+        while (list)
+        {
+                next = list->next;
+                if (list->cmds)
+                {
+                        i = 0;
+                        while (list->cmds[i])
+                                ft_free(list->cmds[i++]);
+                        ft_free(list->cmds);
+                }
+                while (list->rediraction)
+                {
+                        r_next = list->rediraction->next;
+                        ft_free(list->rediraction->token);
+                        ft_free(list->rediraction);
+                        list->rediraction = r_next;
+                }
+                ft_free(list);
+                list = next;
+        }
 }

--- a/main_program/minishell.c
+++ b/main_program/minishell.c
@@ -67,6 +67,7 @@ int	main(int ac, char **av, char **env)
                         execution(list, env);
                 }
                 print_command_list(list);
+                free_command_list(list);
         }
         return (0);
 }

--- a/main_program/minishell.h
+++ b/main_program/minishell.h
@@ -112,6 +112,7 @@ void						free_tokens(t_tokens *tokens);
 t_tokens					*variable_expansion(t_tokens *tokens);
 t_list						*tokens_to_list(t_tokens *tokens);
 void						print_command_list(t_list *list);
+void						free_command_list(t_list *list);
 t_gc						**static_gc(void);
 void						ft_free_all(void);
 int							append_gc(void *ptr);

--- a/main_program/utils.c
+++ b/main_program/utils.c
@@ -18,9 +18,7 @@ char *ft_strdup(const char *s)
     char    *cpy;
 
     i = 0;
-    cpy = malloc(ft_strlen((char *)s) + 1);
-    if (!cpy)
-        return (NULL);
+    cpy = ft_malloc(ft_strlen((char *)s) + 1);
     while (s[i])
     {
         cpy[i] = s[i];


### PR DESCRIPTION
## Summary
- Track command list allocations via the garbage collector
- Duplicate token strings and free original token list after building command list
- Add GC-backed command list cleanup to release commands and redirections

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_689e0559d8a08326871e21210ceb97ae