### PR TITLE
Add export and unset builtins with robust exit status handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ SRCS = main_program/minishell.c \
        builtins/ft_pwd.c \
        builtins/ft_env.c \
        builtins/ft_exit.c \
+       builtins/ft_export.c \
+       builtins/ft_unset.c \
+       builtins/env_utils.c \
        main_program/utils.c \
        main_program/ft_split.c \
        main_program/execution.c \

--- a/builtins/builtins.c
+++ b/builtins/builtins.c
@@ -17,8 +17,9 @@ int	is_builtin(char *cmd)
 {
 	if (!cmd)
 		return (0);
-	return (!strcmp(cmd, "echo") || !strcmp(cmd, "cd") || !strcmp(cmd, "pwd") ||
-			!strcmp(cmd, "env") || !strcmp(cmd, "exit") );
+        return (!strcmp(cmd, "echo") || !strcmp(cmd, "cd") || !strcmp(cmd, "pwd") ||
+                        !strcmp(cmd, "env") || !strcmp(cmd, "exit") ||
+                        !strcmp(cmd, "export") || !strcmp(cmd, "unset"));
 }
 
 int	run_builtin(char **cmd, char ***env)
@@ -26,15 +27,19 @@ int	run_builtin(char **cmd, char ***env)
 
 	if (!cmd || !cmd[0])
 		return (1);
-	if (!strcmp(cmd[0], "echo"))
-		return (ft_echo(cmd));
-	if (!strcmp(cmd[0], "cd"))
-		return (ft_cd(cmd));
-	if (!strcmp(cmd[0], "pwd"))
-		return (ft_pwd());
-	if (!strcmp(cmd[0], "env"))
-		return (ft_env(*env));
-	if (!strcmp(cmd[0], "exit"))
-		return (ft_exit(cmd));
+        if (!strcmp(cmd[0], "echo"))
+                return (ft_echo(cmd));
+        if (!strcmp(cmd[0], "cd"))
+                return (ft_cd(cmd, env));
+        if (!strcmp(cmd[0], "pwd"))
+                return (ft_pwd(cmd));
+        if (!strcmp(cmd[0], "env"))
+                return (ft_env(cmd, *env));
+        if (!strcmp(cmd[0], "export"))
+                return (ft_export(cmd, env));
+        if (!strcmp(cmd[0], "unset"))
+                return (ft_unset(cmd, env));
+        if (!strcmp(cmd[0], "exit"))
+                return (ft_exit(cmd));
 	return (0);
 }

--- a/builtins/builtins.h
+++ b/builtins/builtins.h
@@ -10,7 +10,6 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-
 #ifndef BUILTINS_H
 # define BUILTINS_H
 
@@ -18,15 +17,20 @@
 # include <stdio.h>
 # include <stdlib.h>
 # include <string.h>
+# include <ctype.h>
 
+int             is_builtin(char *cmd);
+int             run_builtin(char **cmd, char ***env);
+int             ft_echo(char **args);
+int             ft_cd(char **args, char ***env);
+int             ft_pwd(char **args);
+int             ft_exit(char **args);
+int             ft_env(char **args, char **env);
+int             ft_export(char **args, char ***env);
+int             ft_unset(char **args, char ***env);
 
-int		is_builtin(char *cmd);
-int		run_builtin(char **cmd, char ***env);
-int		ft_echo(char **args);
-int		ft_cd(char **args);
-int		ft_pwd(void);
-int		ft_exit(char **args);
-int		ft_env(char **env);
-// int ft_unset(char **args , char **env);
+char           *get_env_value(char **env, const char *name);
+int             set_env_var(char ***env, const char *name, const char *value);
+int             unset_env_var(char ***env, const char *name);
 
 #endif

--- a/builtins/env_utils.c
+++ b/builtins/env_utils.c
@@ -1,0 +1,153 @@
+#include "builtins.h"
+#include "../main_program/minishell.h"
+
+static int  find_env_index(char **env, const char *name)
+{
+        size_t  len;
+        int     i;
+
+        if (!env || !name)
+                return (-1);
+        len = strlen(name);
+        i = 0;
+        while (env[i])
+        {
+                if (!strncmp(env[i], name, len) && env[i][len] == '=')
+                        return (i);
+                i++;
+        }
+        return (-1);
+}
+
+char    *get_env_value(char **env, const char *name)
+{
+        int     idx;
+        char    *eq;
+
+        idx = find_env_index(env, name);
+        if (idx == -1)
+                return (NULL);
+        eq = strchr(env[idx], '=');
+        if (!eq)
+                return (NULL);
+        return (eq + 1);
+}
+
+int     set_env_var(char ***env, const char *name, const char *value)
+{
+        size_t  len_name;
+        size_t  len_value;
+        char    *entry;
+        int     idx;
+        char    **new_env;
+        t_info  *info;
+        t_env   *cur;
+        t_env   *prev;
+        t_env   *node;
+
+        if (!env || !name)
+                return (1);
+        len_name = strlen(name);
+        len_value = value ? strlen(value) : 0;
+        entry = malloc(len_name + 1 + len_value + 1);
+        if (!entry)
+                return (1);
+        memcpy(entry, name, len_name);
+        entry[len_name] = '=';
+        if (value)
+                memcpy(entry + len_name + 1, value, len_value);
+        entry[len_name + 1 + len_value] = '\0';
+        idx = find_env_index(*env, name);
+        if (idx >= 0)
+        {
+                free((*env)[idx]);
+                (*env)[idx] = entry;
+        }
+        else
+        {
+                idx = 0;
+                while ((*env)[idx])
+                        idx++;
+                new_env = realloc(*env, sizeof(char *) * (idx + 2));
+                if (!new_env)
+                        return (free(entry), 1);
+                new_env[idx] = entry;
+                new_env[idx + 1] = NULL;
+                *env = new_env;
+        }
+        info = static_info();
+        cur = info->env;
+        prev = NULL;
+        while (cur)
+        {
+                if (!strncmp(cur->s, name, len_name) && cur->s[len_name] == '=')
+                {
+                        entry = strdup(entry);
+                        if (!entry)
+                                return (1);
+                        free(cur->s);
+                        cur->s = entry;
+                        return (0);
+                }
+                prev = cur;
+                cur = cur->next;
+        }
+        node = malloc(sizeof(t_env));
+        if (!node)
+                return (1);
+        node->s = strdup(entry);
+        if (!node->s)
+                return (free(node), 1);
+        node->next = NULL;
+        if (!prev)
+                info->env = node;
+        else
+                prev->next = node;
+        return (0);
+}
+
+int     unset_env_var(char ***env, const char *name)
+{
+        size_t  len_name;
+        int     i;
+        int     j;
+        t_info  *info;
+        t_env   *cur;
+        t_env   *prev;
+
+        if (!env || !*env || !name)
+                return (1);
+        len_name = strlen(name);
+        i = 0;
+        j = 0;
+        while ((*env)[i])
+        {
+                if (!strncmp((*env)[i], name, len_name) && (*env)[i][len_name] == '=')
+                {
+                        free((*env)[i]);
+                        i++;
+                        continue ;
+                }
+                (*env)[j++] = (*env)[i++];
+        }
+        (*env)[j] = NULL;
+        info = static_info();
+        cur = info->env;
+        prev = NULL;
+        while (cur)
+        {
+                if (!strncmp(cur->s, name, len_name) && cur->s[len_name] == '=')
+                {
+                        if (prev)
+                                prev->next = cur->next;
+                        else
+                                info->env = cur->next;
+                        free(cur->s);
+                        free(cur);
+                        break ;
+                }
+                prev = cur;
+                cur = cur->next;
+        }
+        return (0);
+}

--- a/builtins/ft_cd.c
+++ b/builtins/ft_cd.c
@@ -6,28 +6,52 @@
 /*   By: jait-chd <jait-chd@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/13 21:46:08 by jait-chd          #+#    #+#             */
-/*   Updated: 2025/07/13 21:54:53 by jait-chd         ###   ########.fr       */
+/*   Updated: 2025/08/13 06:57:00 by jait-chd         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-
 #include "builtins.h"
+#include "../main_program/minishell.h"
 
-int	ft_cd(char **args)
+static char *get_home(char **env)
 {
-	if (!args[1])
-	{
-		write(2, "[cd] : is only a shortcut for cd /home so\n", 42);
-		 return (1);
-		// the exit status should be 0
-		 exit(0);
-	}
-	if (chdir(args[1]) != 0)
-	{
-		write(2,"No such file or directory\n" , 27);
-		return (1);
-		exit(0);
-	}
-	return (0);
+        return (get_env_value(env, "HOME"));
 }
-// case 01 chmod folder to 000 and try to enter to it 
+
+int     ft_cd(char **args, char ***env)
+{
+        char    *path;
+        char    oldpwd[1024];
+        char    newpwd[1024];
+
+        if (args[1] && args[2])
+        {
+                write(2, "minishell: cd: too many arguments\n", 34);
+                return (1);
+        }
+        if (!args[1])
+        {
+                path = get_home(*env);
+                if (!path)
+                {
+                        write(2, "minishell: cd: HOME not set\n", 28);
+                        return (1);
+                }
+        }
+        else
+                path = args[1];
+        if (!getcwd(oldpwd, sizeof(oldpwd)))
+                oldpwd[0] = '\0';
+        if (chdir(path) != 0)
+        {
+                write(2, "minishell: cd: ", 16);
+                perror(path);
+                return (1);
+        }
+        if (getcwd(newpwd, sizeof(newpwd)))
+        {
+                set_env_var(env, "OLDPWD", oldpwd);
+                set_env_var(env, "PWD", newpwd);
+        }
+        return (0);
+}

--- a/builtins/ft_env.c
+++ b/builtins/ft_env.c
@@ -6,22 +6,30 @@
 /*   By: jait-chd <jait-chd@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/13 21:46:16 by jait-chd          #+#    #+#             */
-/*   Updated: 2025/07/13 21:46:17 by jait-chd         ###   ########.fr       */
+/*   Updated: 2025/08/13 06:57:00 by jait-chd         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-
 #include "builtins.h"
 
-int	ft_env(char **env)
+int     ft_env(char **args, char **env)
 {
-	int	i = 0;
+        int     i;
 
-	while (env[i])
-	{
-		write(1, env[i], strlen(env[i]));
-		write(1, "\n", 1);
-		i++;
-	}
-	return (0);
+        if (args[1])
+        {
+                write(2, "minishell: env: ", 16);
+                write(2, args[1], strlen(args[1]));
+                write(2, ": No such file or directory\n", 28);
+                return (127);
+        }
+        i = 0;
+        while (env[i])
+        {
+                write(1, env[i], strlen(env[i]));
+                write(1, "\n", 1);
+                i++;
+        }
+        return (0);
 }
+

--- a/builtins/ft_export.c
+++ b/builtins/ft_export.c
@@ -1,0 +1,82 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_export.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jait-chd <jait-chd@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/08/13 06:57:00 by jait-chd          #+#    #+#             */
+/*   Updated: 2025/08/13 06:57:00 by jait-chd         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "builtins.h"
+#include "../main_program/minishell.h"
+
+static int      valid_identifier(const char *s)
+{
+        int     i;
+
+        if (!s || (!isalpha(s[0]) && s[0] != '_'))
+                return (0);
+        i = 1;
+        while (s[i] && s[i] != '=')
+        {
+                if (!isalnum(s[i]) && s[i] != '_')
+                        return (0);
+                i++;
+        }
+        return (1);
+}
+
+int     ft_export(char **args, char ***env)
+{
+        int     i;
+        int     status;
+        char    *name;
+        char    *value;
+        int     len;
+
+        if (!args[1])
+        {
+                i = 0;
+                while ((*env)[i])
+                {
+                        write(1, (*env)[i], strlen((*env)[i]));
+                        write(1, "\n", 1);
+                        i++;
+                }
+                return (0);
+        }
+        i = 1;
+        status = 0;
+        while (args[i])
+        {
+                if (!valid_identifier(args[i]))
+                {
+                        write(2, "minishell: export: `", 20);
+                        write(2, args[i], strlen(args[i]));
+                        write(2, "': not a valid identifier\n", 26);
+                        status = 1;
+                        i++;
+                        continue ;
+                }
+                len = 0;
+                while (args[i][len] && args[i][len] != '=')
+                        len++;
+                name = malloc(len + 1);
+                if (!name)
+                        return (1);
+                memcpy(name, args[i], len);
+                name[len] = '\0';
+                value = NULL;
+                if (args[i][len] == '=')
+                        value = args[i] + len + 1;
+                if (set_env_var(env, name, value))
+                        status = 1;
+                free(name);
+                i++;
+        }
+        return (status);
+}
+

--- a/builtins/ft_pwd.c
+++ b/builtins/ft_pwd.c
@@ -6,39 +6,24 @@
 /*   By: jait-chd <jait-chd@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/13 21:46:23 by jait-chd          #+#    #+#             */
-/*   Updated: 2025/07/13 21:46:24 by jait-chd         ###   ########.fr       */
+/*   Updated: 2025/08/13 06:57:00 by jait-chd         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-
 #include "builtins.h"
 
-int	ft_pwd(void)
+int     ft_pwd(char **args)
 {
-	char	cwd[1024];
+        char    cwd[1024];
 
-	if (getcwd(cwd, sizeof(cwd)))
-	{
-		write(1, cwd, strlen(cwd));
-		write(1, "\n", 1);
-		// exit(0);
-	}
-	else
-		perror("pwd");
-	return (0);
+        (void)args;
+        if (!getcwd(cwd, sizeof(cwd)))
+        {
+                perror("minishell: pwd");
+                return (1);
+        }
+        write(1, cwd, strlen(cwd));
+        write(1, "\n", 1);
+        return (0);
 }
- // pwd + arg must ignore all options next to pwd and affiche pwd
 
- // mkdir test and remove it on another terminal and test pwd
-//  mkdir test_dir
-// cd test_dir
-// chmod 000 .
-// pwd
-// # Should still work (pwd doesn't need read permission)
-// some test cases with symbolic links
-//13. PWD in Pipelines
-//14. PWD with Redirections
-//15. PWD in Subshells
-//16. PWD in Command Substitution
-//18. PWD When $PWD is Modified
-// 19. PWD When $PWD is Unset

--- a/builtins/ft_unset.c
+++ b/builtins/ft_unset.c
@@ -1,0 +1,54 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_unset.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jait-chd <jait-chd@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/08/13 06:57:00 by jait-chd          #+#    #+#             */
+/*   Updated: 2025/08/13 06:57:00 by jait-chd         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "builtins.h"
+#include "../main_program/minishell.h"
+
+static int      valid_identifier(const char *s)
+{
+        int     i;
+
+        if (!s || (!isalpha(s[0]) && s[0] != '_'))
+                return (0);
+        i = 1;
+        while (s[i])
+        {
+                if (!isalnum(s[i]) && s[i] != '_')
+                        return (0);
+                i++;
+        }
+        return (1);
+}
+
+int     ft_unset(char **args, char ***env)
+{
+        int     i;
+        int     status;
+
+        i = 1;
+        status = 0;
+        while (args[i])
+        {
+                if (!valid_identifier(args[i]))
+                {
+                        write(2, "minishell: unset: `", 20);
+                        write(2, args[i], strlen(args[i]));
+                        write(2, "': not a valid identifier\n", 26);
+                        status = 1;
+                }
+                else
+                        unset_env_var(env, args[i]);
+                i++;
+        }
+        return (status);
+}
+


### PR DESCRIPTION
## Summary
- add `export` and `unset` builtins with identifier validation and environment updates
- improve builtin exit statuses and error handling for `cd`, `env`, and `pwd`
- share environment utilities for setting and removing variables

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689f920659e08326bbb71dbc3dffc708