### PR TITLE
Refactor functions to meet 25-line limit

### DIFF
--- a/builtins/ft_exit.c
+++ b/builtins/ft_exit.c
@@ -6,57 +6,52 @@
 /*   By: jait-chd <jait-chd@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/11 05:46:20 by jait-chd          #+#    #+#             */
-/*   Updated: 2025/07/13 21:46:21 by jait-chd         ###   ########.fr       */
+/*   Updated: 2025/06/11 05:46:20 by jait-chd         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtins.h"
 
-int	is_valid_number(char *str)
+int     is_valid_number(char *str)
 {
-	int	i = 0;
-	
-	if (!str || !*str)
-		return (0);
-	
-	if (str[i] == '+' || str[i] == '-')
-		i++;
-	
-	if (!str[i])
-		return (0);
-	while (str[i])
-	{
-		if (str[i] < '0' || str[i] > '9')
-			return (0);
-		i++;
-	}
-	return (1);
+    int     i;
+
+    i = 0;
+    if (!str || !*str)
+        return (0);
+    if (str[i] == '+' || str[i] == '-')
+        i++;
+    if (!str[i])
+        return (0);
+    while (str[i])
+    {
+        if (str[i] < '0' || str[i] > '9')
+            return (0);
+        i++;
+    }
+    return (1);
 }
 
-int	ft_exit(char **args)
+int     ft_exit(char **args)
 {
-	int	code = 0;
-	
-	write(1, "exit\n", 5);
-	
-	if (!args[1])
-		exit(code);
-	
-	if (!is_valid_number(args[1]))
-	{
-		write(2, "minishell: exit: ", 17);
-		write(2, args[1], strlen(args[1]));
-		write(2, ": numeric argument required\n", 28);
-		exit(2);
-	}
-	
-	if (args[2])
-	{
-		write(2, "minishell: exit: too many arguments\n", 36);
-		return (1);
-	}
-	
-	code = atoi(args[1]);
-	exit(code);
+    int     code;
+
+    write(1, "exit\n", 5);
+    if (!args[1])
+        exit(0);
+    if (!is_valid_number(args[1]))
+    {
+        write(2, "minishell: exit: ", 17);
+        write(2, args[1], strlen(args[1]));
+        write(2, ": numeric argument required\n", 28);
+        exit(2);
+    }
+    if (args[2])
+    {
+        write(2, "minishell: exit: too many arguments\n", 36);
+        return (1);
+    }
+    code = atoi(args[1]);
+    exit(code);
 }
 

--- a/main_program/execution.c
+++ b/main_program/execution.c
@@ -129,15 +129,12 @@ static void finalize_execution(int prev_fd, pid_t *pids, int cmd_count)
     free(pids);
 }
 
-void execution(t_list *cmds, char **env)
+static void run_commands(t_list *cmds, char **env,
+        pid_t *pids, int prev_fd)
 {
     int     pipe_fd[2];
-    int     prev_fd;
-    pid_t   *pids;
-    int     cmd_count;
     int     i;
-    if ((cmd_count = init_pids(cmds, &pids, &prev_fd)) < 0)
-        return ;
+
     i = 0;
     while (cmds)
     {
@@ -153,6 +150,18 @@ void execution(t_list *cmds, char **env)
         i++;
     }
     finalize_execution(prev_fd, pids, i);
+}
+
+void    execution(t_list *cmds, char **env)
+{
+    pid_t   *pids;
+    int     prev_fd;
+    int     cmd_count;
+
+    cmd_count = init_pids(cmds, &pids, &prev_fd);
+    if (cmd_count < 0)
+        return ;
+    run_commands(cmds, env, pids, prev_fd);
 }
 
 /* ************************************************************************** */

--- a/main_program/minishell.c
+++ b/main_program/minishell.c
@@ -12,89 +12,98 @@
 
 #include "minishell.h"
 
-int check_what_to_execute(t_list *list, char **env)
+static int  dup_std_fds(int *in, int *out)
 {
-    t_info  *info;
-    int     saved_stdin;
-    int     saved_stdout;
-
-    if (!list->next && is_builtin(list->cmds[0]))
+    *in = dup(STDIN_FILENO);
+    *out = dup(STDOUT_FILENO);
+    if (*in == -1 || *out == -1)
     {
-        saved_stdin = dup(STDIN_FILENO);
-        saved_stdout = dup(STDOUT_FILENO);
-        if (saved_stdin == -1 || saved_stdout == -1)
-        {
-            if (saved_stdin != -1)
-                close(saved_stdin);
-            if (saved_stdout != -1)
-                close(saved_stdout);
-            static_info()->exit_status = 1;
-            return (1);
-        }
-        if (handle_redirections(list) == -1)
-        {
-            dup2(saved_stdin, STDIN_FILENO);
-            dup2(saved_stdout, STDOUT_FILENO);
-            close(saved_stdin);
-            close(saved_stdout);
-            static_info()->exit_status = 1;
-            return (1);
-        }
-        info = static_info();
-        info->exit_status = run_builtin(list->cmds, &env);
-        dup2(saved_stdin, STDIN_FILENO);
-        dup2(saved_stdout, STDOUT_FILENO);
-        close(saved_stdin);
-        close(saved_stdout);
+        if (*in != -1)
+            close(*in);
+        if (*out != -1)
+            close(*out);
         return (1);
     }
     return (0);
 }
 
-void	history(char *line)
+static void restore_std_fds(int in, int out)
 {
-	if (!line || !*line)
-		return ;
-	add_history(line);
+    dup2(in, STDIN_FILENO);
+    dup2(out, STDOUT_FILENO);
+    close(in);
+    close(out);
 }
 
-void	initialise_info(char **env)
+int     check_what_to_execute(t_list *list, char **env)
 {
-	t_info	*info;
+    t_info  *info;
+    int     saved_in;
+    int     saved_out;
 
-	info = static_info();
-	info->env = arr_list(env);
-	info->exit_status = 0;
-}
-
-int	main(int ac, char **av, char **env)
-{
-	char	*line;
-	t_list	*list;
-
-	(void)ac;
-	(void)av;
-	initialise_info(env);
-    signals();
-	while (1)
-	{
-                line = readline(PROMPT);
-                history(line);
-                if (check_input(line))
-                        continue ;
-                list = input_analysis(line);
-                if (!list)
-                {
-                        static_info()->exit_status = 258;
-                        continue ;
-                }
-                prepare_heredocs(list);
-                if (!check_what_to_execute(list, env))
-                {
-                        execution(list, env);
-                }
-                print_command_list(list);
-                free_command_list(list);
-        }
+    if (list->next || !is_builtin(list->cmds[0]))
         return (0);
+    if (dup_std_fds(&saved_in, &saved_out)
+        || handle_redirections(list) == -1)
+    {
+        restore_std_fds(saved_in, saved_out);
+        static_info()->exit_status = 1;
+        return (1);
+    }
+    info = static_info();
+    info->exit_status = run_builtin(list->cmds, &env);
+    restore_std_fds(saved_in, saved_out);
+    return (1);
 }
+
+void    history(char *line)
+{
+    if (!line || !*line)
+        return ;
+    add_history(line);
+}
+
+void    initialise_info(char **env)
+{
+    t_info  *info;
+
+    info = static_info();
+    info->env = arr_list(env);
+    info->exit_status = 0;
+}
+
+static void shell_loop(char **env)
+{
+    char    *line;
+    t_list  *list;
+
+    while (1)
+    {
+        line = readline(PROMPT);
+        history(line);
+        if (check_input(line))
+            continue ;
+        list = input_analysis(line);
+        if (!list)
+        {
+            static_info()->exit_status = 258;
+            continue ;
+        }
+        prepare_heredocs(list);
+        if (!check_what_to_execute(list, env))
+            execution(list, env);
+        print_command_list(list);
+        free_command_list(list);
+    }
+}
+
+int     main(int ac, char **av, char **env)
+{
+    (void)ac;
+    (void)av;
+    initialise_info(env);
+    signals();
+    shell_loop(env);
+    return (0);
+}
+


### PR DESCRIPTION
## Summary
- Break down minishell's main loop and built-in execution handling into smaller helpers to keep functions under 25 lines.
- Refactor ft_exit to streamline numeric validation and argument checks within the 25-line limit.
- Extract command loop from execution.c into a dedicated helper so the public interface stays concise.

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a0998a52dc8326881866e166c10711