### PR TITLE
feat: expand builtin support and status handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ SRCS = main_program/minishell.c \
        builtins/ft_pwd.c \
        builtins/ft_env.c \
        builtins/ft_exit.c \
+       builtins/ft_export.c \
+       builtins/ft_unset.c \
        main_program/utils.c \
        main_program/ft_split.c \
        main_program/execution.c \

--- a/builtins/builtins.c
+++ b/builtins/builtins.c
@@ -6,35 +6,39 @@
 /*   By: jait-chd <jait-chd@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/13 21:45:48 by jait-chd          #+#    #+#             */
-/*   Updated: 2025/07/17 02:22:01 by jait-chd         ###   ########.fr       */
+/*   Updated: 2025/08/13 00:00:00 by ChatGPT         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-
 #include "builtins.h"
 
-int	is_builtin(char *cmd)
+int is_builtin(char *cmd)
 {
-	if (!cmd)
-		return (0);
-	return (!strcmp(cmd, "echo") || !strcmp(cmd, "cd") || !strcmp(cmd, "pwd") ||
-			!strcmp(cmd, "env") || !strcmp(cmd, "exit") );
+        if (!cmd)
+                return (0);
+        return (!strcmp(cmd, "echo") || !strcmp(cmd, "cd")
+                || !strcmp(cmd, "pwd") || !strcmp(cmd, "env")
+                || !strcmp(cmd, "exit") || !strcmp(cmd, "export")
+                || !strcmp(cmd, "unset"));
 }
 
-int	run_builtin(char **cmd, char ***env)
+int run_builtin(char **cmd, char ***env)
 {
-
-	if (!cmd || !cmd[0])
-		return (1);
-	if (!strcmp(cmd[0], "echo"))
-		return (ft_echo(cmd));
-	if (!strcmp(cmd[0], "cd"))
-		return (ft_cd(cmd));
-	if (!strcmp(cmd[0], "pwd"))
-		return (ft_pwd());
-	if (!strcmp(cmd[0], "env"))
-		return (ft_env(*env));
-	if (!strcmp(cmd[0], "exit"))
-		return (ft_exit(cmd));
-	return (0);
+        if (!cmd || !cmd[0])
+                return (1);
+        if (!strcmp(cmd[0], "echo"))
+                return (ft_echo(cmd));
+        if (!strcmp(cmd[0], "cd"))
+                return (ft_cd(cmd));
+        if (!strcmp(cmd[0], "pwd"))
+                return (ft_pwd(cmd));
+        if (!strcmp(cmd[0], "env"))
+                return (ft_env(cmd, *env));
+        if (!strcmp(cmd[0], "export"))
+                return (ft_export(cmd, env));
+        if (!strcmp(cmd[0], "unset"))
+                return (ft_unset(cmd, env));
+        if (!strcmp(cmd[0], "exit"))
+                return (ft_exit(cmd));
+        return (1);
 }

--- a/builtins/builtins.h
+++ b/builtins/builtins.h
@@ -6,10 +6,9 @@
 /*   By: jait-chd <jait-chd@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/13 21:46:05 by jait-chd          #+#    #+#             */
-/*   Updated: 2025/07/17 02:22:24 by jait-chd         ###   ########.fr       */
+/*   Updated: 2025/08/13 00:00:00 by ChatGPT         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
-
 
 #ifndef BUILTINS_H
 # define BUILTINS_H
@@ -18,15 +17,16 @@
 # include <stdio.h>
 # include <stdlib.h>
 # include <string.h>
+# include "../main_program/minishell.h"
 
-
-int		is_builtin(char *cmd);
-int		run_builtin(char **cmd, char ***env);
-int		ft_echo(char **args);
-int		ft_cd(char **args);
-int		ft_pwd(void);
-int		ft_exit(char **args);
-int		ft_env(char **env);
-// int ft_unset(char **args , char **env);
+int is_builtin(char *cmd);
+int run_builtin(char **cmd, char ***env);
+int ft_echo(char **args);
+int ft_cd(char **args);
+int ft_pwd(char **args);
+int ft_exit(char **args);
+int ft_env(char **args, char **env);
+int ft_export(char **args, char ***env);
+int ft_unset(char **args, char ***env);
 
 #endif

--- a/builtins/ft_cd.c
+++ b/builtins/ft_cd.c
@@ -6,28 +6,26 @@
 /*   By: jait-chd <jait-chd@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/13 21:46:08 by jait-chd          #+#    #+#             */
-/*   Updated: 2025/07/13 21:54:53 by jait-chd         ###   ########.fr       */
+/*   Updated: 2025/08/13 00:00:00 by ChatGPT         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-
 #include "builtins.h"
 
-int	ft_cd(char **args)
+int ft_cd(char **args)
 {
-	if (!args[1])
-	{
-		write(2, "[cd] : is only a shortcut for cd /home so\n", 42);
-		 return (1);
-		// the exit status should be 0
-		 exit(0);
-	}
-	if (chdir(args[1]) != 0)
-	{
-		write(2,"No such file or directory\n" , 27);
-		return (1);
-		exit(0);
-	}
-	return (0);
+        char *path;
+
+        if (args[1] && args[2])
+                return (write(2, "minishell: cd: too many arguments\n", 34), 1);
+        path = args[1] ? args[1] : getenv("HOME");
+        if (!path)
+                return (write(2, "minishell: cd: HOME not set\n", 28), 1);
+        if (chdir(path))
+        {
+                write(2, "minishell: cd: ", 15);
+                perror(path);
+                return (1);
+        }
+        return (0);
 }
-// case 01 chmod folder to 000 and try to enter to it 

--- a/builtins/ft_echo.c
+++ b/builtins/ft_echo.c
@@ -6,47 +6,44 @@
 /*   By: jait-chd <jait-chd@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/13 21:46:13 by jait-chd          #+#    #+#             */
-/*   Updated: 2025/07/13 21:46:13 by jait-chd         ###   ########.fr       */
+/*   Updated: 2025/08/13 00:00:00 by ChatGPT         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-
 #include "builtins.h"
 
-
-static int is_valid_n_flag(const char *arg)
+static int is_n(char *s)
 {
-	if (arg[0] != '-')
-		return (0);
-	for (int i = 1; arg[i]; i++)
-	{
-		if (arg[i] != 'n')
-			return (0);
-	}
-	return (1);
+        int i;
+
+        if (!s || s[0] != '-')
+                return (0);
+        i = 1;
+        while (s[i] == 'n')
+                i++;
+        return (s[i] == '\0');
 }
-
-
 
 int ft_echo(char **args)
 {
-	int i = 1;
-	int newline = 1;
-	while (args[i] && is_valid_n_flag(args[i]))
-	{
-		newline = 0;
-		i++;
-	}
-	while (args[i])
-	{
-		write(1, args[i], strlen(args[i]));
-		if (args[i + 1])
-			write(1, " ", 1);
-		i++;
-	}
+        int i;
+        int nl;
 
-	if (newline)
-		write(1, "\n", 1);
-
-	return (0);
+        i = 1;
+        nl = 1;
+        while (args[i] && is_n(args[i]))
+        {
+                nl = 0;
+                i++;
+        }
+        while (args[i])
+        {
+                write(1, args[i], strlen(args[i]));
+                if (args[i + 1])
+                        write(1, " ", 1);
+                i++;
+        }
+        if (nl)
+                write(1, "\n", 1);
+        return (0);
 }

--- a/builtins/ft_env.c
+++ b/builtins/ft_env.c
@@ -6,22 +6,27 @@
 /*   By: jait-chd <jait-chd@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/13 21:46:16 by jait-chd          #+#    #+#             */
-/*   Updated: 2025/07/13 21:46:17 by jait-chd         ###   ########.fr       */
+/*   Updated: 2025/08/13 00:00:00 by ChatGPT         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-
 #include "builtins.h"
 
-int	ft_env(char **env)
+int ft_env(char **args, char **env)
 {
-	int	i = 0;
+        int i;
 
-	while (env[i])
-	{
-		write(1, env[i], strlen(env[i]));
-		write(1, "\n", 1);
-		i++;
-	}
-	return (0);
+        if (args[1])
+                return (write(2, "minishell: env: too many arguments\n", 35), 1);
+        i = 0;
+        while (env[i])
+        {
+                if (strchr(env[i], '='))
+                {
+                        write(1, env[i], strlen(env[i]));
+                        write(1, "\n", 1);
+                }
+                i++;
+        }
+        return (0);
 }

--- a/builtins/ft_exit.c
+++ b/builtins/ft_exit.c
@@ -6,52 +6,47 @@
 /*   By: jait-chd <jait-chd@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/11 05:46:20 by jait-chd          #+#    #+#             */
-/*   Updated: 2025/06/11 05:46:20 by jait-chd         ###   ########.fr       */
+/*   Updated: 2025/08/13 00:00:00 by ChatGPT         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtins.h"
+#include <ctype.h>
 
-int     is_valid_number(char *str)
+static int numeric(char *s)
 {
-    int     i;
+        int i;
 
-    i = 0;
-    if (!str || !*str)
-        return (0);
-    if (str[i] == '+' || str[i] == '-')
-        i++;
-    if (!str[i])
-        return (0);
-    while (str[i])
-    {
-        if (str[i] < '0' || str[i] > '9')
-            return (0);
-        i++;
-    }
-    return (1);
-}
-
-int     ft_exit(char **args)
-{
-    int     code;
-
-    write(1, "exit\n", 5);
-    if (!args[1])
-        exit(0);
-    if (!is_valid_number(args[1]))
-    {
-        write(2, "minishell: exit: ", 17);
-        write(2, args[1], strlen(args[1]));
-        write(2, ": numeric argument required\n", 28);
-        exit(2);
-    }
-    if (args[2])
-    {
-        write(2, "minishell: exit: too many arguments\n", 36);
+        if (!s || !*s)
+                return (0);
+        i = 0;
+        if (s[i] == '+' || s[i] == '-')
+                i++;
+        while (s[i])
+                if (!isdigit((unsigned char)s[i++]))
+                        return (0);
         return (1);
-    }
-    code = atoi(args[1]);
-    exit(code);
 }
 
+int ft_exit(char **args)
+{
+        int code;
+
+        write(1, "exit\n", 5);
+        if (!args[1])
+                exit(0);
+        if (!numeric(args[1]))
+        {
+                write(2, "minishell: exit: ", 17);
+                write(2, args[1], strlen(args[1]));
+                write(2, ": numeric argument required\n", 28);
+                exit(2);
+        }
+        if (args[2])
+        {
+                write(2, "minishell: exit: too many arguments\n", 36);
+                return (1);
+        }
+        code = atoi(args[1]);
+        exit(code);
+}

--- a/builtins/ft_export.c
+++ b/builtins/ft_export.c
@@ -1,0 +1,56 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_export.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ChatGPT <chatgpt@example.com>               +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/08/13 00:00:00 by ChatGPT          #+#    #+#             */
+/*   Updated: 2025/08/13 00:00:00 by ChatGPT         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "builtins.h"
+#include <ctype.h>
+#include <string.h>
+extern char **environ;
+
+static int valid(char *s)
+{
+        int i;
+
+        if (!s || (!isalpha((unsigned char)s[0]) && s[0] != '_'))
+                return (0);
+        i = 1;
+        while (s[i] && s[i] != '=')
+        {
+                if (!isalnum((unsigned char)s[i]) && s[i] != '_')
+                        return (0);
+                i++;
+        }
+        return (1);
+}
+
+int ft_export(char **a, char ***e)
+{
+        int i = 1, st = 0; char *eq, *name;
+
+        if (!a[1])
+                return (ft_env(a, *e));
+        while (a[i])
+        {
+                if (!valid(a[i]))
+                        (write(2, "minishell: export: `", 20),
+                        write(2, a[i], strlen(a[i])),
+                        write(2, "': not a valid identifier\n", 26), st = 1);
+                else if ((eq = strchr(a[i], '=')))
+                        (name = ft_substr(a[i], eq - a[i]), setenv(name, eq + 1, 1),
+                        ft_free(name));
+                else
+                        setenv(a[i], "", 1);
+                i++;
+        }
+        *e = environ;
+        static_info()->env = arr_list(*e);
+        return (st);
+}

--- a/builtins/ft_pwd.c
+++ b/builtins/ft_pwd.c
@@ -6,39 +6,21 @@
 /*   By: jait-chd <jait-chd@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/13 21:46:23 by jait-chd          #+#    #+#             */
-/*   Updated: 2025/07/13 21:46:24 by jait-chd         ###   ########.fr       */
+/*   Updated: 2025/08/13 00:00:00 by ChatGPT         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-
 #include "builtins.h"
 
-int	ft_pwd(void)
+int ft_pwd(char **args)
 {
-	char	cwd[1024];
+        char cwd[1024];
 
-	if (getcwd(cwd, sizeof(cwd)))
-	{
-		write(1, cwd, strlen(cwd));
-		write(1, "\n", 1);
-		// exit(0);
-	}
-	else
-		perror("pwd");
-	return (0);
+        if (args[1] && args[1][0] == '-' && args[1][1])
+                return (write(2, "minishell: pwd: invalid option\n", 31), 1);
+        if (!getcwd(cwd, sizeof(cwd)))
+                return (perror("pwd"), 1);
+        write(1, cwd, strlen(cwd));
+        write(1, "\n", 1);
+        return (0);
 }
- // pwd + arg must ignore all options next to pwd and affiche pwd
-
- // mkdir test and remove it on another terminal and test pwd
-//  mkdir test_dir
-// cd test_dir
-// chmod 000 .
-// pwd
-// # Should still work (pwd doesn't need read permission)
-// some test cases with symbolic links
-//13. PWD in Pipelines
-//14. PWD with Redirections
-//15. PWD in Subshells
-//16. PWD in Command Substitution
-//18. PWD When $PWD is Modified
-// 19. PWD When $PWD is Unset

--- a/builtins/ft_unset.c
+++ b/builtins/ft_unset.c
@@ -1,0 +1,51 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_unset.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ChatGPT <chatgpt@example.com>               +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/08/13 00:00:00 by ChatGPT          #+#    #+#             */
+/*   Updated: 2025/08/13 00:00:00 by ChatGPT         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "builtins.h"
+#include <ctype.h>
+#include <string.h>
+extern char **environ;
+
+static int valid(char *s)
+{
+        int i;
+
+        if (!s || (!isalpha((unsigned char)s[0]) && s[0] != '_'))
+                return (0);
+        i = 1;
+        while (s[i])
+        {
+                if (!isalnum((unsigned char)s[i]) && s[i] != '_')
+                        return (0);
+                i++;
+        }
+        return (1);
+}
+
+int ft_unset(char **a, char ***e)
+{
+        int i = 1, st = 0;
+
+        while (a[i])
+        {
+                if (!valid(a[i]))
+                        (write(2, "minishell: unset: `", 19),
+                        write(2, a[i], strlen(a[i])),
+                        write(2, "': not a valid identifier\n", 26), st = 1);
+                else
+                        unsetenv(a[i]);
+                i++;
+        }
+        *e = environ;
+        static_info()->env = arr_list(*e);
+        return (st);
+}

--- a/main_program/minishell.c
+++ b/main_program/minishell.c
@@ -35,7 +35,7 @@ static void restore_std_fds(int in, int out)
     close(out);
 }
 
-int     check_what_to_execute(t_list *list, char **env)
+int     check_what_to_execute(t_list *list, char ***env)
 {
     t_info  *info;
     int     saved_in;
@@ -51,7 +51,7 @@ int     check_what_to_execute(t_list *list, char **env)
         return (1);
     }
     info = static_info();
-    info->exit_status = run_builtin(list->cmds, &env);
+    info->exit_status = run_builtin(list->cmds, env);
     restore_std_fds(saved_in, saved_out);
     return (1);
 }
@@ -90,7 +90,7 @@ static void shell_loop(char **env)
             continue ;
         }
         prepare_heredocs(list);
-        if (!check_what_to_execute(list, env))
+        if (!check_what_to_execute(list, &env))
             execution(list, env);
         print_command_list(list);
         free_command_list(list);


### PR DESCRIPTION
## Summary
- add unset and export builtins with identifier validation
- improve existing builtins and track exit status
- propagate environment changes and compile new sources

## Testing
- `make`
- `printf "export TEST=1\nenv | grep TEST\nunset TEST\nenv | grep TEST\nexit\n" | ./minishell`


------
https://chatgpt.com/codex/tasks/task_e_68a0b201254c8326ae5abdf1b3a09f50